### PR TITLE
Add email categorization for Work, Personal, Promotions, and Spam

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -78,3 +78,7 @@ body {
     margin-top: 1rem;
     margin-left: 1rem;
 }
+
+.category-title{
+    margin:10px;
+}

--- a/routes/emails.js
+++ b/routes/emails.js
@@ -9,29 +9,62 @@ router.use(express.urlencoded({ extended: true }));
 router.get("/compose", (req, res) => {
     res.render("./email/compose.ejs");
 });
+
 // to add emails composed to database
 router.post("/", async(req, res) => {
         const email = req.body.email
         const mail = new Email(email);
         await mail.save();
         res.redirect("/emails/");
-    })
-    //to read emails from database
+    });
+
+// Category routes
+
+// Work Emails
+router.get("/work", async (req, res) => {
+    const emails = await Email.find({ label: "work" });
+    res.render("./email/work.ejs", { emails });
+});
+
+// Personal Emails
+router.get("/personal", async (req, res) => {
+    const emails = await Email.find({ label: "personal" });
+    res.render("./email/personal.ejs", { emails });
+});
+
+// Promotions Emails
+router.get("/promotions", async (req, res) => {
+    const emails = await Email.find({ label: "promotions" });
+    res.render("./email/promotions.ejs", { emails });
+});
+
+// Spam Emails
+router.get("/spam", async (req, res) => {
+    const emails = await Email.find({ label: "spam" });
+    res.render("./email/spam.ejs", { emails });
+});
+
+//to read emails from database
 router.get("/", async(req, res) => {
     const emails = await Email.find({});
     res.render("./email/inbox.ejs", { emails });
 });
-// to view indivisual emails
+
+// to view individual emails
 router.get("/:id", async(req, res) => {
     let { id } = req.params;
     const email = await Email.findById(id);
     res.render("./email/show.ejs", { email });
 });
-// to delete indivisual email
+
+// to delete individual email
 router.delete("/:id", async(req, res) => {
     let { id } = req.params;
     const email = await Email.findByIdAndDelete(id);
     res.redirect("/emails/");
-})
+});
+
+
+
 
 module.exports = router;

--- a/views/email/personal.ejs
+++ b/views/email/personal.ejs
@@ -1,0 +1,19 @@
+<% layout("/layouts/bolierplate.ejs") %>
+
+<body>
+    <div class="inbox">
+        <h3 calss=" category-title"><b>Personal Emails</b></h3>
+        <% for (email of emails) { %>
+            <div class="card email badge-body">
+                <div class="card-body">
+                    <span class="badge rounded-pill bg-warning text-dark"><%= email.label %></span>
+                    <h5 class="card-title">
+                        <a href="/emails/<%= email._id %>"><%= email.subject %></a>
+                    </h5>
+                    <h6 class="card-subtitle mb-2 text-muted"><%= email.from %></h6>
+                    <p class="card-text"><%= email.body.substring(0,100) %></p>
+                </div>
+            </div>
+        <% } %>
+    </div>
+</body>

--- a/views/email/promotions.ejs
+++ b/views/email/promotions.ejs
@@ -1,0 +1,19 @@
+<% layout("/layouts/bolierplate.ejs") %>
+
+<body>
+    <div class="inbox">
+        <h3 calss=" category-title"><b>Promotions Emails</b></h3>
+        <% for (email of emails) { %>
+            <div class="card email badge-body">
+                <div class="card-body">
+                    <span class="badge rounded-pill bg-info text-dark"><%= email.label %></span>
+                    <h5 class="card-title">
+                        <a href="/emails/<%= email._id %>"><%= email.subject %></a>
+                    </h5>
+                    <h6 class="card-subtitle mb-2 text-muted"><%= email.from %></h6>
+                    <p class="card-text"><%= email.body.substring(0,100) %></p>
+                </div>
+            </div>
+        <% } %>
+    </div>
+</body>

--- a/views/email/spam.ejs
+++ b/views/email/spam.ejs
@@ -1,0 +1,19 @@
+<% layout("/layouts/bolierplate.ejs") %>
+
+<body>
+    <div class="inbox">
+        <h3 calss=" category-title"><b>Spam Emails</b></h3>
+        <% for (email of emails) { %>
+            <div class="card email badge-body">
+                <div class="card-body">
+                    <span class="badge rounded-pill bg-danger"><%= email.label %></span>
+                    <h5 class="card-title">
+                        <a href="/emails/<%= email._id %>"><%= email.subject %></a>
+                    </h5>
+                    <h6 class="card-subtitle mb-2 text-muted"><%= email.from %></h6>
+                    <p class="card-text"><%= email.body.substring(0,100) %></p>
+                </div>
+            </div>
+        <% } %>
+    </div>
+</body>

--- a/views/email/work.ejs
+++ b/views/email/work.ejs
@@ -1,0 +1,22 @@
+<% layout("/layouts/bolierplate.ejs") %>
+
+<% layout("/layouts/bolierplate.ejs") %>
+
+<body>
+    <div class="inbox">
+        <h3 calss=" category-title"><b>Work Emails</b></h3>
+        <% for (email of emails) { %>
+            <div class="card email badge-body">
+                <div class="card-body">
+                    <span class="badge rounded-pill bg-success"><%= email.label %></span>
+                    <h5 class="card-title">
+                        <a href="/emails/<%= email._id %>"><%= email.subject %></a>
+                    </h5>
+                    <h6 class="card-subtitle mb-2 text-muted"><%= email.from %></h6>
+                    <p class="card-text"><%= email.body.substring(0,100) %></p>
+                </div>
+            </div>
+        <% } %>
+    </div>
+</body>
+

--- a/views/includes/navbar.ejs
+++ b/views/includes/navbar.ejs
@@ -24,16 +24,16 @@
                         <a class="nav-link active" aria-current="page" href="/emails/"><button type="button" class="btn btn-primary">All Inbox</button></a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" href="#"><button type="button" class="btn btn-success">Work</button></a>
+                        <a class="nav-link active" aria-current="page" href="/emails/work"><button type="button" class="btn btn-success">Work</button></a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" href="#"><button type="button" class="btn btn-warning">Personal</button></a>
+                        <a class="nav-link active" aria-current="page" href="/emails/personal"><button type="button" class="btn btn-warning">Personal</button></a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" href="#"><button type="button" class="btn btn-info">Promotions</button></a>
+                        <a class="nav-link active" aria-current="page" href="/emails/promotions"><button type="button" class="btn btn-info">Promotions</button></a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" aria-current="page" href="#"><button type="button" class="btn btn-danger">Spam</button></a>
+                        <a class="nav-link active" aria-current="page" href="/emails/spam"><button type="button" class="btn btn-danger">Spam</button></a>
                     </li>
 
                 </ul>


### PR DESCRIPTION
This PR adds email categorization with separate routes and views for Work, Personal, Promotions, and Spam emails:

Each category has its own EJS view using the existing card layout.
Emails are fetched from the database based on their label.
The branch name was updated to email-categorization for clarity.